### PR TITLE
feat(expirations): add expiration id and paginated GraphQL queries

### DIFF
--- a/src/main/java/com/igniscore/api/controller/ExpirationController.java
+++ b/src/main/java/com/igniscore/api/controller/ExpirationController.java
@@ -1,6 +1,7 @@
 package com.igniscore.api.controller;
 
 import com.igniscore.api.dto.expiration.ExpirationDTO;
+import com.igniscore.api.dto.expiration.ExpirationPageDTO;
 import com.igniscore.api.service.ExpirationService;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
@@ -22,26 +23,44 @@ public class ExpirationController {
     }
 
     @QueryMapping
-    public List<ExpirationDTO> expirations() {
-        return expirationService.getExpirations();
-    }
-
-    @QueryMapping
-    public List<ExpirationDTO> expirationsByPeriod(@Argument LocalDate startDate, @Argument LocalDate endDate) {
-        return expirationService.getExpirationsByPeriod(startDate, endDate);
-    }
-
-    @QueryMapping
-    public List<ExpirationDTO> upcomingExpirations(
-            @Argument Integer days
+    public ExpirationPageDTO expirations(
+            @Argument Integer page,
+            @Argument Integer size
     ) {
-        return expirationService.getUpcomingExpirations(days);
+        return expirationService.getExpirations(page, size);
     }
 
     @QueryMapping
-    public List<ExpirationDTO> expirationsByClient(
-            @Argument Integer clientId
+    public ExpirationPageDTO expirationsByPeriod(@Argument LocalDate startDate,
+                                                   @Argument LocalDate endDate,
+                                                   @Argument Integer page,
+                                                   @Argument Integer size) {
+        return expirationService.getExpirationsByPeriod(startDate, endDate, page, size);
+    }
+
+    @QueryMapping
+    public ExpirationPageDTO upcomingExpirations(
+            @Argument Integer days,
+            @Argument Integer page,
+            @Argument Integer size
     ) {
-        return expirationService.getExpirationsByClient(clientId);
+        return expirationService.getUpcomingExpirations(
+                days,
+                page,
+                size
+        );
+    }
+
+    @QueryMapping
+    public ExpirationPageDTO expirationsByClient(
+            @Argument Integer clientId,
+            @Argument Integer page,
+            @Argument Integer size
+    ) {
+        return expirationService.getExpirationsByClient(
+                clientId,
+                page,
+                size
+        );
     }
 }

--- a/src/main/java/com/igniscore/api/dto/expiration/ExpirationDTO.java
+++ b/src/main/java/com/igniscore/api/dto/expiration/ExpirationDTO.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ExpirationDTO(
+        Integer expirationId,
         Integer saleId,
         String clientName,
         LocalDate saleDate,

--- a/src/main/java/com/igniscore/api/dto/expiration/ExpirationPageDTO.java
+++ b/src/main/java/com/igniscore/api/dto/expiration/ExpirationPageDTO.java
@@ -1,0 +1,11 @@
+package com.igniscore.api.dto.expiration;
+
+import java.util.List;
+
+public record ExpirationPageDTO(
+        List<ExpirationDTO> items,
+        long totalItems,
+        int totalPages,
+        int currentPage,
+        int pageSize
+) {}

--- a/src/main/java/com/igniscore/api/dto/expiration/ExpirationProjectionDTO.java
+++ b/src/main/java/com/igniscore/api/dto/expiration/ExpirationProjectionDTO.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ExpirationProjectionDTO(
+        Integer expirationId,
         Integer saleId,
         String clientName,
         LocalDate saleDate,

--- a/src/main/java/com/igniscore/api/repository/ExpirationRepository.java
+++ b/src/main/java/com/igniscore/api/repository/ExpirationRepository.java
@@ -2,6 +2,8 @@ package com.igniscore.api.repository;
 
 import com.igniscore.api.dto.expiration.ExpirationProjectionDTO;
 import com.igniscore.api.model.Expiration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,7 @@ public interface ExpirationRepository extends JpaRepository<Expiration, Integer>
 
     @Query("""
     SELECT new com.igniscore.api.dto.expiration.ExpirationProjectionDTO(
+        e.id,
         s.id,
         c.name,
         s.date,
@@ -26,12 +29,14 @@ public interface ExpirationRepository extends JpaRepository<Expiration, Integer>
     WHERE s.company.id = :companyId
     ORDER BY s.dueDate ASC
     """)
-    List<ExpirationProjectionDTO> findExpirationsByCompanyId(
-            @Param("companyId") Integer companyId
+    Page<ExpirationProjectionDTO> findExpirationsByCompanyId(
+            @Param("companyId") Integer companyId,
+            Pageable pageable
     );
 
     @Query("""
     SELECT new com.igniscore.api.dto.expiration.ExpirationProjectionDTO(
+        e.id,
         s.id,
         c.name,
         s.date,
@@ -46,14 +51,16 @@ public interface ExpirationRepository extends JpaRepository<Expiration, Integer>
       AND s.dueDate BETWEEN :startDate AND :endDate
     ORDER BY s.dueDate ASC
     """)
-    List<ExpirationProjectionDTO> findExpirationsByPeriod(
+    Page<ExpirationProjectionDTO> findExpirationsByPeriod(
             @Param("companyId") Integer companyId,
             @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
     );
 
     @Query("""
     SELECT new com.igniscore.api.dto.expiration.ExpirationProjectionDTO(
+        e.id,
         s.id,
         c.name,
         s.date,
@@ -68,14 +75,16 @@ public interface ExpirationRepository extends JpaRepository<Expiration, Integer>
       AND s.dueDate BETWEEN :startDate AND :endDate
     ORDER BY s.dueDate ASC
     """)
-    List<ExpirationProjectionDTO> findUpcomingExpirations(
+    Page<ExpirationProjectionDTO> findUpcomingExpirations(
             @Param("companyId") Integer companyId,
             @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
     );
 
     @Query("""
     SELECT new com.igniscore.api.dto.expiration.ExpirationProjectionDTO(
+        e.id,
         s.id,
         c.name,
         s.date,
@@ -90,8 +99,9 @@ public interface ExpirationRepository extends JpaRepository<Expiration, Integer>
       AND c.id = :clientId
     ORDER BY s.dueDate ASC
     """)
-    List<ExpirationProjectionDTO> findExpirationsByClient(
+    Page<ExpirationProjectionDTO> findExpirationsByClient(
             @Param("companyId") Integer companyId,
-            @Param("clientId") Integer clientId
+            @Param("clientId") Integer clientId,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/igniscore/api/service/ExpirationService.java
+++ b/src/main/java/com/igniscore/api/service/ExpirationService.java
@@ -1,11 +1,13 @@
 package com.igniscore.api.service;
 
 import com.igniscore.api.dto.expiration.ExpirationDTO;
+import com.igniscore.api.dto.expiration.ExpirationPageDTO;
 import com.igniscore.api.dto.expiration.ExpirationProjectionDTO;
 import com.igniscore.api.model.Company;
-import com.igniscore.api.model.ExpirationStatus;
 import com.igniscore.api.repository.ExpirationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -25,71 +27,119 @@ public class ExpirationService {
     }
 
 
-    public List<ExpirationDTO> getExpirations() {
-        Company company = authenticatedUserService.getCompanyOrThrow();
-
-        return expirationRepository
-                .findExpirationsByCompanyId(company.getId())
-                .stream()
-                .map(this::mapExpiration)
-                .toList();
-    }
-
-    public List<ExpirationDTO> getExpirationsByPeriod(
-            LocalDate startDate,
-            LocalDate endDate
+    public ExpirationPageDTO getExpirations(
+            Integer page,
+            Integer size
     ) {
         Company company = authenticatedUserService.getCompanyOrThrow();
 
-        return expirationRepository
-                .findExpirationsByPeriod(
+        Page<ExpirationProjectionDTO> result =
+                expirationRepository.findExpirationsByCompanyId(
                         company.getId(),
-                        startDate,
-                        endDate
-                )
-                .stream()
-                .map(this::mapExpiration)
-                .toList();
+                        PageRequest.of(page, size)
+                );
+
+        return new ExpirationPageDTO(
+                result.getContent()
+                        .stream()
+                        .map(this::mapExpiration)
+                        .toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.getNumber(),
+                result.getSize()
+        );
     }
 
-    public List<ExpirationDTO> getUpcomingExpirations(
-            Integer days
+    public ExpirationPageDTO getExpirationsByPeriod(
+            LocalDate startDate,
+            LocalDate endDate,
+            Integer page,
+            Integer size
+    ) {
+        Company company = authenticatedUserService.getCompanyOrThrow();
+
+        Page<ExpirationProjectionDTO> result =
+                expirationRepository.findExpirationsByPeriod(
+                        company.getId(),
+                        startDate,
+                        endDate,
+                        PageRequest.of(page, size)
+                );
+
+        return new ExpirationPageDTO(
+                result.getContent()
+                        .stream()
+                        .map(this::mapExpiration)
+                        .toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.getNumber(),
+                result.getSize()
+        );
+    }
+
+    public ExpirationPageDTO getUpcomingExpirations(
+            Integer days,
+            Integer page,
+            Integer size
     ) {
         Company company = authenticatedUserService.getCompanyOrThrow();
 
         LocalDate today = LocalDate.now();
         LocalDate endDate = today.plusDays(days);
 
-        return expirationRepository
-                .findUpcomingExpirations(
+        Page<ExpirationProjectionDTO> result =
+                expirationRepository.findUpcomingExpirations(
                         company.getId(),
                         today,
-                        endDate
-                )
-                .stream()
-                .map(this::mapExpiration)
-                .toList();
+                        endDate,
+                        PageRequest.of(page, size)
+                );
+
+        return new ExpirationPageDTO(
+                result.getContent()
+                        .stream()
+                        .map(this::mapExpiration)
+                        .toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.getNumber(),
+                result.getSize()
+        );
     }
 
-    public List<ExpirationDTO> getExpirationsByClient(
-            Integer clientId
+    public ExpirationPageDTO getExpirationsByClient(
+            Integer clientId,
+            Integer page,
+            Integer size
     ) {
         Company company = authenticatedUserService.getCompanyOrThrow();
 
-        return expirationRepository
-                .findExpirationsByClient(
+        Page<ExpirationProjectionDTO> result =
+                expirationRepository.findExpirationsByClient(
                         company.getId(),
-                        clientId
-                )
-                .stream()
-                .map(this::mapExpiration)
-                .toList();
+                        clientId,
+                        PageRequest.of(page, size)
+                );
+
+        return new ExpirationPageDTO(
+                result.getContent()
+                        .stream()
+                        .map(this::mapExpiration)
+                        .toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.getNumber(),
+                result.getSize()
+        );
     }
 
     private ExpirationDTO mapExpiration(
             ExpirationProjectionDTO expiration
     ) {
         return new ExpirationDTO(
+                expiration.expirationId(),
                 expiration.saleId(),
                 expiration.clientName(),
                 expiration.saleDate(),

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -128,20 +128,29 @@ type Query {
 
     salesByClient: [SalesByClient!]!
 
-    expirations: [Expiration!]!
+    expirations(
+        page: Int!,
+        size: Int!
+    ): ExpirationPage!
 
     expirationsByPeriod(
         startDate: Date!,
-        endDate: Date!
-    ): [Expiration!]!
+        endDate: Date!,
+        page: Int!,
+        size: Int!
+    ): ExpirationPage!
 
     upcomingExpirations(
-        days: Int!
-    ): [Expiration!]!
+        days: Int!,
+        page: Int!,
+        size: Int!
+    ): ExpirationPage!
 
     expirationsByClient(
-        clientId: Int!
-    ): [Expiration!]!
+        clientId: Int!,
+        page: Int!,
+        size: Int!
+    ): ExpirationPage!
 }
 
 type ClientQuery {
@@ -168,12 +177,21 @@ type SaleQuery {
 }
 
 type Expiration {
+    expirationId: Int!
     saleId: Int!
     clientName: String!
     saleDate: Date!
     dueDate: Date!
     totalSale: BigDecimal!
     status: ExpirationStatus!
+}
+
+type ExpirationPage {
+    items: [Expiration!]!
+    totalItems: Int!
+    totalPages: Int!
+    currentPage: Int!
+    pageSize: Int!
 }
 
 type Mutation {


### PR DESCRIPTION
- add expirationId to ExpirationDTO and ExpirationProjectionDTO
- update repository projections to include expiration entity id
- implement pagination using Spring Data Page and Pageable
- create ExpirationPageDTO with items and pagination metadata
- update expiration service to return paginated responses
- add paginated queries for expirations, upcoming expirations, period filtering and client filtering
- expose totalItems, totalPages, currentPage and pageSize in GraphQL schema